### PR TITLE
Add evaluation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,72 @@ chest-xray-pneumonia-detector/
 
 ## How to Contribute (and test Jules)
 This project uses Jules, our Async Development Agent, for feature development and bug fixes. Create detailed issues for Jules to work on.
+
+## Training the Model
+
+Run `train_engine.py` to train the classifier. Choose the model architecture with `--model_type` (defaults to `simple`):
+
+```bash
+python src/train_engine.py --model_type mobilenet
+```
+
+Available options are `simple`, `mobilenet`, and `vgg`.
+
+## Visualizing Predictions with Grad-CAM
+
+After training a model, generate a Grad-CAM heatmap overlay. The last convolutional layer can be supplied via `--layer`. If omitted, the script attempts to automatically detect it:
+
+```bash
+python src/grad_cam.py --model saved_models/pneumonia_cnn_v1.keras \
+  --image path/to/xray.jpg --output overlay.png
+
+# explicitly specify the layer if automatic detection fails
+python src/grad_cam.py --model saved_models/pneumonia_cnn_v1.keras \
+  --image path/to/xray.jpg --layer last_conv_layer_name --output overlay.png
+```
+
+Replace `last_conv_layer_name` with the name of your model's last convolutional layer.
+
+Alternatively, you can call the helper in `src/predict_utils.py` which now also
+prints the predicted probability. By default it saves an overlay image unless
+`--no_overlay` is specified:
+
+```bash
+python src/predict_utils.py --model saved_models/pneumonia_cnn_v1.keras \
+  --image path/to/xray.jpg
+
+# disable Grad-CAM generation
+python src/predict_utils.py --model saved_models/pneumonia_cnn_v1.keras \
+  --image path/to/xray.jpg --no_overlay
+```
+
+The console output includes the predicted pneumonia probability and, when
+enabled, the location of the saved overlay.
+
+## Running the Prediction API
+
+To serve the trained model as a simple Flask API, run:
+
+```bash
+python src/serve_model.py
+```
+
+Send a POST request to `http://localhost:5000/predict` with an image file using
+`curl`:
+
+```bash
+curl -X POST -F file=@path/to/xray.jpg http://localhost:5000/predict
+```
+
+## Evaluating a Saved Model
+
+After training, you can assess model performance on a directory of test images using `evaluate_model.py`.
+You may specify the input image size and optionally save a confusion matrix plot:
+
+```bash
+python src/evaluate_model.py --model saved_models/pneumonia_cnn_v1.keras \
+  --data path/to/test_dir --batch_size 16 \
+  --target_size 150 150 --confusion_matrix cm.png
+```
+
+The script prints overall accuracy, a classification report, and a confusion matrix.

--- a/src/evaluate_model.py
+++ b/src/evaluate_model.py
@@ -1,0 +1,117 @@
+import argparse
+import os
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras.preprocessing.image import ImageDataGenerator
+from sklearn.metrics import classification_report, confusion_matrix, accuracy_score
+import matplotlib.pyplot as plt
+
+
+def evaluate_model(
+    model_path,
+    test_dir,
+    target_size=(150, 150),
+    batch_size=32,
+    class_mode="binary",
+    cm_path=None,
+):
+    """Evaluate a trained model on a directory of test images.
+
+    Args:
+        model_path (str): Path to the saved Keras model.
+        test_dir (str): Directory containing test images organized in class folders.
+        target_size (tuple): Image size expected by the model.
+        batch_size (int): Batch size for the data generator.
+        class_mode (str): 'binary' or 'categorical' depending on the model.
+    """
+    if not os.path.exists(model_path):
+        raise FileNotFoundError(f"Model not found: {model_path}")
+    if not os.path.exists(test_dir):
+        raise FileNotFoundError(f"Test directory not found: {test_dir}")
+
+    model = tf.keras.models.load_model(model_path)
+
+    datagen = ImageDataGenerator(rescale=1.0 / 255)
+    generator = datagen.flow_from_directory(
+        test_dir,
+        target_size=target_size,
+        batch_size=batch_size,
+        class_mode=class_mode,
+        shuffle=False,
+    )
+
+    predictions = model.predict(generator, verbose=1)
+    if class_mode == "binary":
+        y_pred = (predictions > 0.5).astype(int).ravel()
+    else:
+        y_pred = np.argmax(predictions, axis=1)
+
+    y_true = generator.classes
+
+    acc = accuracy_score(y_true, y_pred)
+    print(f"Accuracy: {acc:.4f}")
+    print("\nClassification Report:")
+    target_names = list(generator.class_indices.keys())
+    print(classification_report(y_true, y_pred, target_names=target_names))
+
+    cm = confusion_matrix(y_true, y_pred)
+    print("Confusion Matrix:")
+    print(cm)
+
+    if cm_path:
+        fig, ax = plt.subplots(figsize=(5, 4))
+        im = ax.imshow(cm, interpolation="nearest", cmap="Blues")
+        plt.colorbar(im, ax=ax)
+        ax.set(xticks=range(len(target_names)), yticks=range(len(target_names)))
+        ax.set_xticklabels(target_names, rotation=45, ha="right")
+        ax.set_yticklabels(target_names)
+        ax.set_xlabel("Predicted")
+        ax.set_ylabel("True")
+        plt.tight_layout()
+        plt.savefig(cm_path)
+        plt.close(fig)
+        print(f"Confusion matrix plot saved to {cm_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate a trained model")
+    parser.add_argument("--model", required=True, help="Path to the Keras model")
+    parser.add_argument("--data", required=True, help="Directory of test images")
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=32,
+        help="Batch size for evaluation",
+    )
+    parser.add_argument(
+        "--target_size",
+        type=int,
+        nargs=2,
+        metavar=("HEIGHT", "WIDTH"),
+        default=[150, 150],
+        help="Input image size",
+    )
+    parser.add_argument(
+        "--class_mode",
+        choices=["binary", "categorical"],
+        default="binary",
+        help="Model output type",
+    )
+    parser.add_argument(
+        "--confusion_matrix",
+        help="Optional path to save confusion matrix plot",
+    )
+    args = parser.parse_args()
+
+    evaluate_model(
+        model_path=args.model,
+        test_dir=args.data,
+        target_size=tuple(args.target_size),
+        batch_size=args.batch_size,
+        class_mode=args.class_mode,
+        cm_path=args.confusion_matrix,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/grad_cam.py
+++ b/src/grad_cam.py
@@ -1,5 +1,9 @@
+import argparse
+import os
 import numpy as np
 import tensorflow as tf
+import matplotlib.pyplot as plt
+from tensorflow.keras.preprocessing import image
 
 def generate_grad_cam(model, image_array, last_conv_layer_name):
     """
@@ -14,22 +18,118 @@ def generate_grad_cam(model, image_array, last_conv_layer_name):
                                     in the model to be used for Grad-CAM.
 
     Returns:
-        # This function will eventually return a heatmap array.
-        # For now, it's a stub.
-        pass
+        np.ndarray: Normalized heatmap highlighting influential regions.
     """
-    pass
+
+    grad_model = tf.keras.models.Model(
+        [model.inputs],
+        [model.get_layer(last_conv_layer_name).output, model.output]
+    )
+
+    with tf.GradientTape() as tape:
+        conv_outputs, predictions = grad_model(image_array)
+        if predictions.shape[-1] == 1:
+            loss = predictions[:, 0]
+        else:
+            class_idx = tf.argmax(predictions[0])
+            loss = predictions[:, class_idx]
+
+    grads = tape.gradient(loss, conv_outputs)
+    pooled_grads = tf.reduce_mean(grads, axis=(0, 1, 2))
+
+    conv_outputs = conv_outputs[0]
+    heatmap = conv_outputs @ pooled_grads[..., tf.newaxis]
+    heatmap = tf.squeeze(heatmap)
+
+    heatmap = tf.maximum(heatmap, 0) / tf.reduce_max(heatmap)
+    return heatmap.numpy()
+
+
+def find_last_conv_layer(model):
+    """Return the name of the last convolutional layer in ``model``.
+
+    This is useful when a layer name is not explicitly provided. The function
+    searches the model's layers in reverse order and returns the first layer
+    whose output has four dimensions (``rank == 4``), which typically
+    corresponds to a convolutional feature map.
+    """
+    for layer in reversed(model.layers):
+        try:
+            if len(layer.output_shape) == 4:
+                return layer.name
+        except AttributeError:
+            continue
+    raise ValueError("No convolutional layer found in the model.")
+
+
+def overlay_heatmap_on_image(img, heatmap, alpha=0.4, cmap="viridis"):
+    """Overlay a heatmap onto an image.
+
+    Args:
+        img (np.ndarray): Original image as a NumPy array in the range [0, 1].
+        heatmap (np.ndarray): Heatmap from :func:`generate_grad_cam`.
+        alpha (float): Transparency factor for heatmap overlay.
+        cmap (str): Matplotlib colormap to colorize the heatmap.
+
+    Returns:
+        np.ndarray: The image with the heatmap overlay applied.
+    """
+
+    if heatmap.max() == 0:
+        heatmap_normalized = heatmap
+    else:
+        heatmap_normalized = heatmap / heatmap.max()
+
+    cmap = plt.get_cmap(cmap)
+    colored_heatmap = cmap(heatmap_normalized)
+    colored_heatmap = colored_heatmap[..., :3]  # Drop alpha channel
+
+    if img.max() > 1:
+        img = img / 255.0
+
+    overlay = colored_heatmap * alpha + img * (1 - alpha)
+    overlay = np.clip(overlay, 0, 1)
+    return (overlay * 255).astype("uint8")
 
 if __name__ == '__main__':
-    # This section can be used for basic testing or demonstration later.
-    # For now, it will just confirm the script can be run.
-    print("grad_cam.py executed. Contains generate_grad_cam function stub.")
+    parser = argparse.ArgumentParser(description="Generate Grad-CAM heatmap")
+    parser.add_argument("--model", required=True, help="Path to Keras model")
+    parser.add_argument("--image", required=True, help="Path to image file")
+    parser.add_argument(
+        "--layer",
+        help="Name of the last convolutional layer for Grad-CAM. If omitted, the script attempts to detect it automatically.",
+    )
+    parser.add_argument(
+        "--output",
+        default="grad_cam_overlay.png",
+        help="Path to save the overlay image",
+    )
+    args = parser.parse_args()
 
-    # Example of how you might get a last convolutional layer name (for context):
-    # model = tf.keras.applications.VGG16(weights="imagenet")
-    # last_conv_layer_name_example = ""
-    # for layer in reversed(model.layers):
-    #     if len(layer.output_shape) == 4: # Check if it's a conv layer (4D output: batch, H, W, C)
-    #         last_conv_layer_name_example = layer.name
-    #         break
-    # print(f"Example last conv layer name for VGG16: {last_conv_layer_name_example}")
+    if not os.path.exists(args.model):
+        raise FileNotFoundError(f"Model not found: {args.model}")
+    if not os.path.exists(args.image):
+        raise FileNotFoundError(f"Image not found: {args.image}")
+
+    model = tf.keras.models.load_model(args.model)
+
+    img = image.load_img(args.image, target_size=model.input_shape[1:3])
+    img_array = image.img_to_array(img) / 255.0
+    input_array = np.expand_dims(img_array, axis=0)
+
+    layer_name = args.layer
+    if not layer_name:
+        try:
+            layer_name = find_last_conv_layer(model)
+            print(f"Automatically selected layer '{layer_name}' for Grad-CAM")
+        except ValueError as e:
+            raise RuntimeError(
+                "Could not automatically determine the last convolutional layer. "
+                "Please specify it with --layer"
+            ) from e
+
+    heatmap = generate_grad_cam(model, input_array, layer_name)
+    overlay = overlay_heatmap_on_image(img_array, heatmap)
+
+    plt.imsave(args.output, overlay)
+    print(f"Grad-CAM overlay saved to {args.output}")

--- a/src/predict_utils.py
+++ b/src/predict_utils.py
@@ -1,0 +1,115 @@
+import argparse
+import os
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras.preprocessing import image
+import matplotlib.pyplot as plt
+
+from grad_cam import (
+    generate_grad_cam,
+    overlay_heatmap_on_image,
+    find_last_conv_layer,
+)
+
+
+def predict_image(model, img_array):
+    """Return the model's raw prediction for ``img_array``.
+
+    Args:
+        model (tf.keras.Model): Loaded Keras model.
+        img_array (np.ndarray): Preprocessed single image of shape (H, W, C) with
+            values in ``[0, 1]``.
+
+    Returns:
+        float: Probability of pneumonia as predicted by the model.
+    """
+
+    input_array = np.expand_dims(img_array, axis=0)
+    prediction = model.predict(input_array, verbose=0)[0][0]
+    return float(prediction)
+
+
+def display_grad_cam(
+    model_path,
+    image_path,
+    layer_name=None,
+    output_path="grad_cam_result.png",
+):
+    """Generate and save a Grad-CAM overlay for an image using a saved model.
+
+    Args:
+        model_path (str): Path to a Keras model file.
+        image_path (str): Path to the image to analyze.
+        layer_name (str, optional): Name of the last convolutional layer to use.
+            If ``None``, the layer is automatically detected.
+        output_path (str): Path to save the resulting overlay image.
+
+    Returns:
+        str: Path to the saved overlay image.
+    """
+    if not os.path.exists(model_path):
+        raise FileNotFoundError(f"Model not found: {model_path}")
+    if not os.path.exists(image_path):
+        raise FileNotFoundError(f"Image not found: {image_path}")
+
+    model = tf.keras.models.load_model(model_path)
+
+    img = image.load_img(image_path, target_size=model.input_shape[1:3])
+    img_array = image.img_to_array(img) / 255.0
+    input_array = np.expand_dims(img_array, axis=0)
+
+    if layer_name is None:
+        layer_name = find_last_conv_layer(model)
+
+    heatmap = generate_grad_cam(model, input_array, layer_name)
+    overlay = overlay_heatmap_on_image(img_array, heatmap)
+
+    plt.imsave(output_path, overlay)
+    return output_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run prediction and optional Grad-CAM overlay"
+    )
+    parser.add_argument("--model", required=True, help="Path to Keras model")
+    parser.add_argument("--image", required=True, help="Path to image file")
+    parser.add_argument(
+        "--layer",
+        help="Name of last conv layer (auto if omitted)",
+    )
+    parser.add_argument(
+        "--output",
+        default="grad_cam_result.png",
+        help="Where to save the overlay",
+    )
+    parser.add_argument(
+        "--no_overlay",
+        action="store_true",
+        help="Skip Grad-CAM generation and only output the prediction",
+    )
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.model):
+        raise FileNotFoundError(f"Model not found: {args.model}")
+    if not os.path.exists(args.image):
+        raise FileNotFoundError(f"Image not found: {args.image}")
+
+    model = tf.keras.models.load_model(args.model)
+    img = image.load_img(args.image, target_size=model.input_shape[1:3])
+    img_array = image.img_to_array(img) / 255.0
+
+    prob = predict_image(model, img_array)
+    print(f"Predicted pneumonia probability: {prob:.4f}")
+
+    if not args.no_overlay:
+        layer = args.layer or find_last_conv_layer(model)
+        heatmap = generate_grad_cam(model, np.expand_dims(img_array, 0), layer)
+        overlay = overlay_heatmap_on_image(img_array, heatmap)
+        plt.imsave(args.output, overlay)
+        print(f"Grad-CAM saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `evaluate_model.py` for computing metrics on a test set
- document how to run the evaluation helper
- add confusion matrix plotting and target size configuration

## Testing
- `python -m py_compile src/data_loader.py src/model_builder.py src/train_engine.py src/serve_model.py src/validate_data.py src/grad_cam.py src/predict_utils.py src/evaluate_model.py`


------
https://chatgpt.com/codex/tasks/task_e_6856bc50b2948329b865ffca2ec5e4bb

## Summary by Sourcery

Add a full-featured evaluation script and enrich model visualization and training workflows with transfer learning support and unified CLI tools

New Features:
- Add evaluate_model.py CLI to assess models on test data with accuracy, classification report, and optional confusion matrix plotting
- Extend train_engine script with a --model_type flag to support simple, MobileNetV2, and VGG16 architectures
- Introduce CLI interfaces in grad_cam.py and predict_utils.py for generating and saving Grad-CAM overlays with automatic layer detection and probability reporting

Enhancements:
- Implement generate_grad_cam, find_last_conv_layer, and overlay_heatmap_on_image to produce real Grad-CAM heatmaps
- Add create_transfer_learning_model in model_builder.py for building and compiling MobileNetV2/VGG16–based models
- Log model_type parameter to MLflow during training runs

Documentation:
- Update README.md with usage instructions for training, Grad-CAM visualization, prediction API, and model evaluation