### PR TITLE
Add evaluation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,74 @@ chest-xray-pneumonia-detector/
 
 ## How to Contribute (and test Jules)
 This project uses Jules, our Async Development Agent, for feature development and bug fixes. Create detailed issues for Jules to work on.
+
+## Model Evaluation
+
+`src/train_engine.py` now saves a validation confusion matrix to `reports/confusion_matrix_val.png` after training. The script also prints precision, recall, F1-score and ROC AUC on the validation set.
+
+## Training CLI
+
+Run the training loop directly from the terminal with custom directories and parameters:
+
+```bash
+python -m src.train_engine \
+    --train_dir path/to/train \
+    --val_dir path/to/val \
+    --epochs 10 \
+    --batch_size 32 \
+    --use_transfer_learning \
+    --base_model_name MobileNetV2
+```
+
+Use `--use_dummy_data` (the default) to quickly test the pipeline with a small generated dataset.
+
+## Grad-CAM Visualization
+
+`src/predict_utils.py` now exposes a small command-line interface to create Grad-CAM overlays. It loads the model, processes the image and saves an overlay showing which regions contributed most to the prediction.
+
+Example usage:
+
+```bash
+python -m src.predict_utils \
+    --model_path saved_models/pneumonia_cnn_v1.keras \
+    --img_path path/to/image.jpg \
+    --last_conv_layer_name conv_pw_13_relu \
+    --output_path gradcam.png \
+    --img_size 150 150
+```
+
+## Batch Inference
+
+`src/inference.py` provides a simple CLI for running a trained model on a directory of images.
+It outputs a CSV file with predictions for each image.
+
+```bash
+python -m src.inference \
+    --model_path saved_models/pneumonia_cnn_v1.keras \
+    --data_dir path/to/images \
+    --output_csv preds.csv
+```
+
+## Evaluate Predictions
+
+`src/evaluate.py` can compute precision, recall, F1-score and ROC AUC from a CSV of model predictions and optional labels. It also saves a confusion matrix plot.
+
+```bash
+python -m src.evaluate \
+    --pred_csv preds.csv \
+    --label_csv labels.csv \
+    --output_png eval_confusion.png
+```
+
+## Experiment Tracking
+
+`train_engine.py` now logs parameters, metrics and artifacts using MLflow. Run the script and then view the recorded runs with:
+
+```bash
+mlflow ui
+```
+
+## Attention-based Model
+
+The training engine can optionally build a CNN incorporating Squeeze-and-Excitation blocks for attention.
+Set `USE_ATTENTION_MODEL = True` in `train_engine.py` to enable this architecture.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+mlflow
+tensorflow
+pandas
+seaborn
+scikit-learn

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -1,0 +1,82 @@
+import argparse
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+from sklearn.metrics import (
+    precision_score,
+    recall_score,
+    f1_score,
+    roc_auc_score,
+    confusion_matrix,
+)
+
+
+def evaluate_predictions(pred_csv: str, label_csv: str | None = None, output_png: str = "reports/confusion_matrix.png"):
+    """Evaluate predictions stored in ``pred_csv``.
+
+    Parameters
+    ----------
+    pred_csv:
+        CSV with columns ``filepath`` and ``prediction``.
+    label_csv:
+        Optional CSV with columns ``filepath`` and ``label``. If not provided,
+        ``pred_csv`` must already contain a ``label`` column.
+    output_png:
+        Path to save the confusion matrix plot.
+    """
+    df = pd.read_csv(pred_csv)
+    if "label" not in df.columns:
+        if label_csv is None:
+            raise ValueError("No ground truth labels provided")
+        labels = pd.read_csv(label_csv)
+        df = df.merge(labels, on="filepath")
+
+    y_true = df["label"].values
+    y_probs = df["prediction"].values
+    y_pred = (y_probs > 0.5).astype(int)
+
+    precision = precision_score(y_true, y_pred, zero_division=0)
+    recall = recall_score(y_true, y_pred, zero_division=0)
+    f1 = f1_score(y_true, y_pred, zero_division=0)
+    roc_auc = roc_auc_score(y_true, y_probs)
+
+    cm = confusion_matrix(y_true, y_pred)
+    sns.heatmap(cm, annot=True, fmt="d", cmap="Blues")
+    plt.xlabel("Predicted")
+    plt.ylabel("True")
+    plt.tight_layout()
+    plt.savefig(output_png)
+    plt.close()
+
+    return {
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "roc_auc": roc_auc,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Evaluate prediction CSV")
+    parser.add_argument("--pred_csv", required=True, help="CSV with predictions")
+    parser.add_argument("--label_csv", help="CSV with ground truth labels")
+    parser.add_argument(
+        "--img_size",
+        type=int,
+        nargs=2,
+        default=[150, 150],
+        metavar=("HEIGHT", "WIDTH"),
+        help="Unused. For backward compatibility",
+    )
+    parser.add_argument(
+        "--output_png", default="reports/confusion_matrix.png", help="Output confusion matrix image"
+    )
+    args = parser.parse_args()
+
+    metrics = evaluate_predictions(args.pred_csv, args.label_csv, args.output_png)
+    for k, v in metrics.items():
+        print(f"{k}: {v:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/inference.py
+++ b/src/inference.py
@@ -1,0 +1,64 @@
+import argparse
+import pandas as pd
+import tensorflow as tf
+from tensorflow.keras.preprocessing import image
+
+
+def predict_directory(model_path: str, data_dir: str, img_size=(150, 150)) -> pd.DataFrame:
+    """Generate predictions for all images in a directory.
+
+    Parameters
+    ----------
+    model_path : str
+        Path to a saved Keras model.
+    data_dir : str
+        Directory containing images organised in subfolders. Only file paths are used;
+        no label inference is performed.
+    img_size : tuple, optional
+        Image size expected by the model.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with columns ``filepath`` and ``prediction``.
+    """
+    model = tf.keras.models.load_model(model_path)
+
+    datagen = image.ImageDataGenerator(rescale=1.0 / 255)
+    generator = datagen.flow_from_directory(
+        data_dir,
+        target_size=img_size,
+        class_mode=None,
+        shuffle=False,
+        batch_size=32,
+    )
+
+    preds = model.predict(generator)
+    preds = preds.reshape(-1)
+
+    df = pd.DataFrame({"filepath": generator.filepaths, "prediction": preds})
+    return df
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Batch inference on a directory of images")
+    parser.add_argument("--model_path", required=True, help="Path to a saved Keras model")
+    parser.add_argument("--data_dir", required=True, help="Directory with images organised in class folders")
+    parser.add_argument(
+        "--img_size",
+        type=int,
+        nargs=2,
+        default=[150, 150],
+        metavar=("HEIGHT", "WIDTH"),
+        help="Image size expected by the model",
+    )
+    parser.add_argument("--output_csv", default="predictions.csv", help="Where to save predictions")
+    args = parser.parse_args()
+
+    df = predict_directory(args.model_path, args.data_dir, tuple(args.img_size))
+    df.to_csv(args.output_csv, index=False)
+    print(f"Saved predictions to {args.output_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/model_builder.py
+++ b/src/model_builder.py
@@ -1,9 +1,78 @@
 import tensorflow as tf
 from tensorflow.keras.models import Sequential, Model
-from tensorflow.keras.layers import Conv2D, MaxPooling2D, Flatten, Dense, GlobalAveragePooling2D
+from tensorflow.keras.layers import (
+    Conv2D,
+    MaxPooling2D,
+    Flatten,
+    Dense,
+    GlobalAveragePooling2D,
+    Reshape,
+    multiply,
+)
 from tensorflow.keras.optimizers import Adam
 from tensorflow.keras.losses import BinaryCrossentropy, CategoricalCrossentropy
 from tensorflow.keras.applications import MobileNetV2, VGG16
+
+
+def create_transfer_learning_model(
+    input_shape,
+    num_classes=1,
+    base_model_name="MobileNetV2",
+    trainable_base_layers=0,
+):
+    """Create a transfer learning model with a configurable base.
+
+    Parameters
+    ----------
+    input_shape : tuple
+        Shape of the input images, e.g. ``(height, width, channels)``.
+    num_classes : int, optional
+        Number of output classes. ``1`` assumes binary classification.
+    base_model_name : str, optional
+        Name of the keras application model to use. Currently supports
+        ``"MobileNetV2"`` and ``"VGG16"``.
+    trainable_base_layers : int, optional
+        Number of layers at the end of the base model to unfreeze for
+        fine-tuning. ``0`` keeps the base frozen.
+
+    Returns
+    -------
+    tf.keras.Model
+        A compiled Keras model ready for training.
+    """
+
+    if base_model_name == "MobileNetV2":
+        base_model = MobileNetV2(
+            include_top=False, input_shape=input_shape, weights="imagenet"
+        )
+    elif base_model_name == "VGG16":
+        base_model = VGG16(
+            include_top=False, input_shape=input_shape, weights="imagenet"
+        )
+    else:
+        raise ValueError(
+            "Unsupported base_model_name. Use 'MobileNetV2' or 'VGG16'."
+        )
+
+    base_model.trainable = False
+
+    inputs = tf.keras.Input(shape=input_shape)
+    x = base_model(inputs, training=False)
+    x = GlobalAveragePooling2D()(x)
+
+    activation = "sigmoid" if num_classes == 1 else "softmax"
+    loss = BinaryCrossentropy() if num_classes == 1 else CategoricalCrossentropy()
+
+    outputs = Dense(num_classes, activation=activation)(x)
+    model = Model(inputs, outputs)
+
+    model.compile(optimizer=Adam(), loss=loss, metrics=["accuracy"])
+
+    if trainable_base_layers > 0:
+        for layer in base_model.layers[-trainable_base_layers:]:
+            layer.trainable = True
+
+    return model
 
 
 def create_simple_cnn(input_shape, num_classes=1):
@@ -42,6 +111,40 @@ def create_simple_cnn(input_shape, num_classes=1):
         loss=BinaryCrossentropy(),
         metrics=['accuracy'] # Common metric to monitor
     )
+
+    return model
+
+
+def _squeeze_excite_block(inputs, ratio=16):
+    """Squeeze-and-Excitation block used for attention."""
+    filters = inputs.shape[-1]
+    se = GlobalAveragePooling2D()(inputs)
+    se = Dense(filters // ratio, activation="relu")(se)
+    se = Dense(filters, activation="sigmoid")(se)
+    se = Reshape((1, 1, filters))(se)
+    return multiply([inputs, se])
+
+
+def create_cnn_with_attention(input_shape, num_classes=1):
+    """Build a simple CNN with Squeeze-and-Excitation attention blocks."""
+
+    inputs = tf.keras.Input(shape=input_shape)
+    x = Conv2D(32, (3, 3), activation="relu")(inputs)
+    x = MaxPooling2D((2, 2))(x)
+    x = _squeeze_excite_block(x)
+
+    x = Conv2D(64, (3, 3), activation="relu")(x)
+    x = MaxPooling2D((2, 2))(x)
+    x = _squeeze_excite_block(x)
+
+    x = Flatten()(x)
+    x = Dense(128, activation="relu")(x)
+    activation = "sigmoid" if num_classes == 1 else "softmax"
+    outputs = Dense(num_classes, activation=activation)(x)
+
+    model = Model(inputs, outputs)
+    loss = BinaryCrossentropy() if num_classes == 1 else CategoricalCrossentropy()
+    model.compile(optimizer=Adam(), loss=loss, metrics=["accuracy"])
 
     return model
 

--- a/src/predict_utils.py
+++ b/src/predict_utils.py
@@ -1,0 +1,91 @@
+import argparse
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras.preprocessing import image
+import matplotlib.pyplot as plt
+
+from grad_cam import generate_grad_cam
+
+
+def load_image(img_path, target_size):
+    img = image.load_img(img_path, target_size=target_size)
+    img_array = image.img_to_array(img)
+    img_array = np.expand_dims(img_array, axis=0)
+    img_array = img_array / 255.0
+    return img_array
+
+
+def display_grad_cam(
+    model_path: str,
+    img_path: str,
+    target_size=(150, 150),
+    last_conv_layer_name: str = "conv_pw_13_relu",
+    output_path: str = "grad_cam_output.png",
+):
+    """Generate and save a Grad-CAM overlay for a given image.
+
+    Parameters
+    ----------
+    model_path: str
+        Path to a saved Keras model.
+    img_path: str
+        Path to the input image.
+    target_size: tuple
+        Size to which the image will be resized.
+    last_conv_layer_name: str
+        Name of the convolutional layer used for Grad-CAM.
+    output_path: str
+        Where to save the Grad-CAM overlay image.
+    """
+
+    model = tf.keras.models.load_model(model_path)
+    img_array = load_image(img_path, target_size)
+
+    heatmap = generate_grad_cam(model, img_array, last_conv_layer_name)
+
+    heatmap = np.uint8(255 * heatmap)
+    heatmap = np.expand_dims(heatmap, axis=2)
+    heatmap = tf.image.resize(heatmap, target_size).numpy().astype("uint8")
+    heatmap = np.squeeze(heatmap)
+
+    original = image.load_img(img_path, target_size=target_size)
+    original = image.img_to_array(original).astype("uint8")
+
+    plt.imshow(original / 255.0)
+    plt.imshow(heatmap, cmap="jet", alpha=0.4)
+    plt.axis("off")
+    plt.savefig(output_path, bbox_inches="tight")
+    plt.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate Grad-CAM overlays")
+    parser.add_argument("--model_path", required=True, help="Path to Keras model")
+    parser.add_argument("--img_path", required=True, help="Path to input image")
+    parser.add_argument(
+        "--last_conv_layer_name",
+        default="conv_pw_13_relu",
+        help="Name of the convolutional layer for Grad-CAM",
+    )
+    parser.add_argument(
+        "--output_path",
+        default="grad_cam_output.png",
+        help="Where to save the Grad-CAM overlay image",
+    )
+    parser.add_argument(
+        "--img_size",
+        type=int,
+        nargs=2,
+        default=[150, 150],
+        metavar=("HEIGHT", "WIDTH"),
+        help="Size to which the image will be resized",
+    )
+    args = parser.parse_args()
+
+    display_grad_cam(
+        model_path=args.model_path,
+        img_path=args.img_path,
+        target_size=tuple(args.img_size),
+        last_conv_layer_name=args.last_conv_layer_name,
+        output_path=args.output_path,
+    )

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,11 @@
+import pytest
+
+tf = pytest.importorskip("tensorflow")
+from src.data_loader import create_data_generators
+
+
+def test_missing_directories(tmp_path):
+    train_dir = tmp_path / "train"
+    val_dir = tmp_path / "val"
+    train_gen, val_gen = create_data_generators(str(train_dir), str(val_dir))
+    assert train_gen is None and val_gen is None

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,9 @@
+import subprocess
+import sys
+import pytest
+
+pytest.importorskip("tensorflow")
+
+def test_evaluate_cli_help():
+    result = subprocess.run([sys.executable, "-m", "src.evaluate", "--help"], capture_output=True)
+    assert result.returncode == 0

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,10 @@
+import subprocess
+import sys
+import pytest
+
+pytest.importorskip("tensorflow")
+
+
+def test_inference_cli_help():
+    result = subprocess.run([sys.executable, "-m", "src.inference", "--help"], capture_output=True)
+    assert result.returncode == 0

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -1,0 +1,16 @@
+import pytest
+
+# Skip tests if TensorFlow is unavailable
+tf = pytest.importorskip("tensorflow")
+
+from src.model_builder import create_simple_cnn, create_cnn_with_attention
+
+
+def test_simple_cnn_output_shape():
+    model = create_simple_cnn((32, 32, 3))
+    assert model.output_shape == (None, 1)
+
+
+def test_attention_cnn_output_shape():
+    model = create_cnn_with_attention((32, 32, 3))
+    assert model.output_shape == (None, 1)

--- a/tests/test_predict_utils.py
+++ b/tests/test_predict_utils.py
@@ -1,0 +1,11 @@
+import sys
+import subprocess
+import pytest
+
+pytest.importorskip("tensorflow")
+
+
+def test_cli_help():
+    result = subprocess.run([sys.executable, "-m", "src.predict_utils", "--help"], capture_output=True)
+    assert result.returncode == 0
+

--- a/tests/test_train_engine.py
+++ b/tests/test_train_engine.py
@@ -1,0 +1,19 @@
+import pytest
+import subprocess
+import sys
+
+tf = pytest.importorskip("tensorflow")
+from src.train_engine import create_dummy_data, cleanup_dummy_data
+
+
+def test_dummy_data_creation_and_cleanup(tmp_path):
+    base_dir = tmp_path / "dummy"
+    create_dummy_data(base_dir=str(base_dir), num_images_per_class=1)
+    assert (base_dir / "train").exists()
+    cleanup_dummy_data(base_dir=str(base_dir))
+    assert not base_dir.exists()
+
+
+def test_train_engine_cli_help():
+    result = subprocess.run([sys.executable, "-m", "src.train_engine", "--help"], capture_output=True)
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- add evaluation CLI in `src.evaluate`
- document prediction evaluation usage in the README
- include seaborn dependency
- test the new CLI can show help output
- map class weights correctly and declare scikit-learn dependency

## Testing
- `pytest -q` *(tests skipped due to missing TensorFlow)*

------
https://chatgpt.com/codex/tasks/task_e_6856dfbcff20832981f1955e55021f62

## Summary by Sourcery

Provide unified CLI tooling for training, inference, evaluation, and visualization; extend model_builder with transfer learning and attention support; integrate MLflow tracking; implement full Grad-CAM heatmap generation; save evaluation artifacts; and update documentation and tests accordingly.

New Features:
- Add CLI interface for training with src.train_engine.py using argparse
- Introduce src.predict_utils.py for generating Grad-CAM overlays
- Add src.evaluate.py to compute metrics and save confusion matrix from prediction CSV
- Add src.inference.py for batch model inference and CSV output
- Extend model_builder with transfer learning and squeeze-and-excitation attention model constructors
- Integrate MLflow for logging parameters, metrics, and artifacts during training

Bug Fixes:
- Correct class weight dictionary mapping to use class labels

Enhancements:
- Save validation confusion matrix and training history plots with seaborn heatmaps
- Implement fine-tuning stage for transfer learning models
- Provide full Grad-CAM heatmap generation in grad_cam.py
- Refactor imports and fallback logic for data_loader and model_builder

Build:
- Add mlflow, pandas, seaborn, scikit-learn to requirements.txt

Documentation:
- Update README with usage for training CLI, evaluation CLI, Grad-CAM, batch inference, MLflow tracking, and attention models

Tests:
- Add pytest tests for training, model builder, data loader, CLI help for train_engine, predict_utils, inference, and evaluate scripts