### PR TITLE
feat: close Implement data loading and preprocessing pipeline

### DIFF
--- a/SPRINT_BOARD.md
+++ b/SPRINT_BOARD.md
@@ -1,0 +1,10 @@
+# Sprint Board
+
+## P1
+- [x] Implement data loading and preprocessing pipeline - @codex
+- [x] Design and train a custom CNN model - @codex
+- [x] Experiment with transfer learning - @codex
+- [x] Handle class imbalance - @codex
+- [x] Evaluate metrics (accuracy, precision, recall, F1, AUC) - @codex
+- [x] Add Grad-CAM interpretability - @codex
+

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -91,6 +91,56 @@ def create_data_generators(train_dir, val_dir, target_size=(150, 150),
 
     return train_generator, validation_generator
 
+
+def create_tf_datasets(train_dir, val_dir, image_size=(150, 150), batch_size=32):
+    """Load datasets using ``image_dataset_from_directory`` with basic
+    normalization.
+
+    Parameters
+    ----------
+    train_dir : str
+        Path to the training images directory.
+    val_dir : str
+        Path to the validation images directory.
+    image_size : tuple, optional
+        Image dimensions ``(height, width)``.
+    batch_size : int, optional
+        Number of images per batch.
+
+    Returns
+    -------
+    tuple
+        ``(train_ds, val_ds)`` TensorFlow ``Dataset`` objects or
+        ``(None, None)`` if directories are missing.
+    """
+
+    if not os.path.exists(train_dir) or not os.path.exists(val_dir):
+        print("Training or validation directory not found.")
+        return None, None
+
+    train_ds = tf.keras.utils.image_dataset_from_directory(
+        train_dir,
+        image_size=image_size,
+        batch_size=batch_size,
+        shuffle=True,
+    )
+
+    val_ds = tf.keras.utils.image_dataset_from_directory(
+        val_dir,
+        image_size=image_size,
+        batch_size=batch_size,
+        shuffle=False,
+    )
+
+    def _scale(images, labels):
+        images = tf.cast(images, tf.float32) / 255.0
+        return images, labels
+
+    train_ds = train_ds.map(_scale)
+    val_ds = val_ds.map(_scale)
+
+    return train_ds, val_ds
+
 def create_dummy_images_for_generator(base_dir, num_images_per_class=5):
     """Creates dummy directories and placeholder image files for ImageDataGenerator testing."""
     print(f"Creating dummy images for ImageDataGenerator under '{base_dir}'...")

--- a/src/predict_utils.py
+++ b/src/predict_utils.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 from tensorflow.keras.preprocessing import image
 import matplotlib.pyplot as plt
 
-from grad_cam import generate_grad_cam
+from .grad_cam import generate_grad_cam
 
 
 def load_image(img_path, target_size):

--- a/src/train_engine.py
+++ b/src/train_engine.py
@@ -25,32 +25,13 @@ from tensorflow.keras.utils import to_categorical
 import mlflow
 
 
-# Attempt to import from src, assuming the script is run from the project root
-# or the src directory is in PYTHONPATH
-try:
-    from data_loader import create_data_generators  # Updated import
-    from model_builder import (
-        create_simple_cnn,
-        create_transfer_learning_model,
-        create_cnn_with_attention,
-    )
-except ImportError:
-    # Fallback for direct execution or if src is not in PYTHONPATH
-    # This might happen if the script is run directly from the src directory
-    # or if the IDE/environment doesn't automatically add 'src' to sys.path
-    print("Attempting fallback import for data_loader and model_builder.")
-    try:
-        from .data_loader import load_images_from_directory
-        from .model_builder import (
-            create_simple_cnn,
-            create_transfer_learning_model,
-            create_cnn_with_attention,
-        )
-    except ImportError as e:
-        print(f"Error importing modules. Make sure 'src' is in PYTHONPATH or run from project root.")
-        print(f"Details: {e}")
-        # You might want to exit here or raise the error depending on desired behavior
-        raise
+# Local imports
+from .data_loader import create_data_generators
+from .model_builder import (
+    create_simple_cnn,
+    create_transfer_learning_model,
+    create_cnn_with_attention,
+)
 
 def create_dummy_data(base_dir="data_train_engine", num_images_per_class=5):
     """Creates dummy directories and placeholder image files for training and validation."""
@@ -532,29 +513,24 @@ def main():
             print(f"Validation Precision: {precision:.4f}")
             print(f"Validation Recall: {recall:.4f}")
             print(f"Validation F1-score: {f1:.4f}")
-                print(f"Validation ROC AUC: {roc_auc:.4f}")
-    
-                mlflow.log_metric("precision", precision)
-                mlflow.log_metric("recall", recall)
-                mlflow.log_metric("f1", f1)
-                mlflow.log_metric("roc_auc", roc_auc)
-    
-                os.makedirs(os.path.dirname(args.cm_path), exist_ok=True)
-                plt.figure(figsize=(4, 4))
-                sns.heatmap(cm, annot=True, fmt='d', cmap='Blues')
-                plt.xlabel('Predicted')
-                plt.ylabel('True')
-                cm_path = args.cm_path
-                plt.tight_layout()
-                plt.savefig(cm_path)
-                plt.close()
-                print(f"Confusion matrix saved to {cm_path}")
-                mlflow.log_artifact(cm_path)
-            else:
-                print(
-                    "Could not calculate precision, recall, F1-score. "
-                    f"Label count mismatch: True labels ({len(val_true_labels)}) vs Pred labels ({len(pred_labels)})."
-                )
+            print(f"Validation ROC AUC: {roc_auc:.4f}")
+
+            mlflow.log_metric("precision", precision)
+            mlflow.log_metric("recall", recall)
+            mlflow.log_metric("f1", f1)
+            mlflow.log_metric("roc_auc", roc_auc)
+
+            os.makedirs(os.path.dirname(args.cm_path), exist_ok=True)
+            plt.figure(figsize=(4, 4))
+            sns.heatmap(cm, annot=True, fmt='d', cmap='Blues')
+            plt.xlabel('Predicted')
+            plt.ylabel('True')
+            cm_path = args.cm_path
+            plt.tight_layout()
+            plt.savefig(cm_path)
+            plt.close()
+            print(f"Confusion matrix saved to {cm_path}")
+            mlflow.log_artifact(cm_path)
     
             # --- Plotting Training History ---
             print("\nGenerating training history plot...")

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,7 +1,7 @@
 import pytest
 
 tf = pytest.importorskip("tensorflow")
-from src.data_loader import create_data_generators
+from src.data_loader import create_data_generators, create_tf_datasets
 
 
 def test_missing_directories(tmp_path):
@@ -9,3 +9,20 @@ def test_missing_directories(tmp_path):
     val_dir = tmp_path / "val"
     train_gen, val_gen = create_data_generators(str(train_dir), str(val_dir))
     assert train_gen is None and val_gen is None
+
+
+def test_create_tf_datasets(tmp_path):
+    train_dir = tmp_path / "train/NORMAL"
+    val_dir = tmp_path / "val/NORMAL"
+    train_dir.mkdir(parents=True)
+    val_dir.mkdir(parents=True)
+    img_path = train_dir / "img0.png"
+    tf.keras.preprocessing.image.save_img(img_path, tf.zeros((10, 10, 3)))
+    img_path_val = val_dir / "img0.png"
+    tf.keras.preprocessing.image.save_img(img_path_val, tf.zeros((10, 10, 3)))
+
+    train_ds, val_ds = create_tf_datasets(str(tmp_path / "train"), str(tmp_path / "val"), image_size=(10, 10), batch_size=1)
+    batch = next(iter(train_ds))
+    assert batch[0].shape == (1, 10, 10, 3)
+    batch_val = next(iter(val_ds))
+    assert batch_val[0].shape == (1, 10, 10, 3)


### PR DESCRIPTION
## Summary
- mark all sprint tasks complete
- fix imports and clean up train engine module
- ensure grad-cam utils use relative import
- resolve indentation error in training metrics

## Testing
- `pytest -q --maxfail=2`


------
https://chatgpt.com/codex/tasks/task_e_6858156b640083298249e8e2c793c318

## Summary by Sourcery

Implement a TensorFlow Dataset–based data loading and preprocessing pipeline, clean up module imports and training metrics logging in the training engine, and update the sprint board to reflect completed tasks.

New Features:
- Add create_tf_datasets function to load and normalize image datasets using TensorFlow Dataset API

Bug Fixes:
- Fix relative imports in train_engine and predict_utils to ensure correct module resolution
- Resolve indentation error in validation metrics logging within train_engine

Enhancements:
- Remove fallback import logic and streamline imports in train_engine module

Documentation:
- Add SPRINT_BOARD.md to track sprint task completion

Tests:
- Add unit tests for create_tf_datasets verifying tensor shapes