### PR TITLE
Add dataclass CLI parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
           pip install -r requirements.txt
-          pip install ruff black pytest
+          pip install ruff black bandit pytest
       - name: Lint
         run: |
           ruff check src
           black --check src
+      - name: Security Scan
+        run: bandit -r src -ll
       - name: Test
         run: pytest -q

--- a/README.md
+++ b/README.md
@@ -216,3 +216,7 @@ It now includes a dataset statistics tool for counting images per class using
 easier reading. The tool exits with an error if the provided path does not exist
 or is not a directory.
 
+
+## Continuous Integration
+
+Every pull request triggers a GitHub Actions workflow that installs project dependencies and runs code quality checks. The pipeline executes `ruff` for linting, `bandit` for a security scan and `pytest` for the test suite.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,0 @@
-# Package initialization

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1,8 +1,11 @@
-import tensorflow as tf
-from tensorflow.keras.preprocessing.image import ImageDataGenerator
+"""Utilities for loading image datasets with optional augmentation."""
+
 import os
 import shutil
+
 from PIL import Image  # For creating dummy images
+import tensorflow as tf
+from tensorflow.keras.preprocessing.image import ImageDataGenerator
 import numpy as np  # For dummy image creation if needed, and for apply_contrast
 
 

--- a/src/data_split.py
+++ b/src/data_split.py
@@ -1,3 +1,5 @@
+"""Utility for splitting a dataset into train, val and test folders."""
+
 import argparse
 import shutil
 from pathlib import Path

--- a/src/dataset_stats.py
+++ b/src/dataset_stats.py
@@ -1,3 +1,5 @@
+"""CLI to count images per class in a dataset directory."""
+
 import argparse
 import json
 from pathlib import Path

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -1,3 +1,5 @@
+"""Utility script to compute metrics and plot a confusion matrix from predictions."""
+
 import argparse
 import pandas as pd
 import seaborn as sns

--- a/src/inference.py
+++ b/src/inference.py
@@ -1,3 +1,5 @@
+"""Command-line interface for running a trained model on a directory of images."""
+
 import argparse
 import pandas as pd
 import tensorflow as tf

--- a/src/model_builder.py
+++ b/src/model_builder.py
@@ -1,3 +1,5 @@
+"""Model-building utilities for the pneumonia detection CNN."""
+
 import tensorflow as tf
 from tensorflow.keras.models import Sequential, Model
 from tensorflow.keras.layers import (

--- a/src/predict_utils.py
+++ b/src/predict_utils.py
@@ -1,3 +1,5 @@
+"""Generate Grad-CAM overlays for images using a trained model."""
+
 import argparse
 import numpy as np
 import tensorflow as tf


### PR DESCRIPTION
## Summary
- add `TrainingArgs` dataclass and `_parse_args` helper in `train_engine.py`
- keep imports at top to satisfy Ruff
- parse command-line arguments into the new dataclass

## Testing
- `ruff check .`
- `bandit -r src -ll`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d2de34d808329a856c8e2a88df705

## Summary by Sourcery

Add dataclass-based CLI parsing for training parameters in train_engine, refactor main to use the new parser, enhance the CI workflow with a Bandit security scan, and document the CI process in the README.

New Features:
- Add TrainingArgs dataclass for training run configuration and _parse_args helper for CLI argument parsing
- Refactor main() to consume TrainingArgs instead of inline argparse logic

Enhancements:
- Relocate argument validation into _parse_args and streamline main() function logic

CI:
- Install bandit in CI and add a security scan step to the GitHub Actions workflow

Documentation:
- Update README to describe the CI pipeline including linting, security scanning, and testing

Chores:
- Remove src/__init__.py to clean up package structure