### PR TITLE
Add sort_by option to dataset stats CLI

### DIFF
--- a/API_USAGE_GUIDE.md
+++ b/API_USAGE_GUIDE.md
@@ -86,9 +86,15 @@ Count the number of images per class in a dataset. You can restrict the scan to 
 ```bash
 cxr-dataset-stats --input_dir path/to/data --json_output counts.json \
     --csv_output counts.csv \
-    --extensions .jpeg .bmp
+    --extensions .jpeg .bmp \
+    --plot_png counts.png
 
-Extensions are case-insensitive and may be provided without a leading dot. Both
-output files list classes in alphabetical order for readability. The command
+Use ``--sort_by count`` to sort results by descending count instead of the
+default alphabetical order.
+
+Extensions are case-insensitive and may be provided without a leading dot. By
+default, output files list classes in alphabetical order for readability. The
+command
 exits with an error if the input path does not exist or is not a directory.
+Plotting requires the optional ``matplotlib`` dependency (install with ``pip install matplotlib``). The PNG output directory must exist.
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,6 @@
 - Extensions are normalized to lower case and may omit the leading dot
 - JSON and CSV outputs are sorted alphabetically by class name
 - Better error messages if the input path does not exist or is not a directory
+- `cxr-dataset-stats` can save a bar chart of class counts via `--plot_png` (requires `matplotlib`)
+- `cxr-dataset-stats` now checks that the PNG output directory exists
+- `cxr-dataset-stats` supports sorting results by count via `--sort_by count`

--- a/README.md
+++ b/README.md
@@ -212,8 +212,10 @@ The guide also shows how to print the package version using the `cxr-version` co
 It now includes a dataset statistics tool for counting images per class using
 `cxr-dataset-stats`. The command accepts a custom list of file extensions via
 `--extensions` (case-insensitive and dot optional). Counts saved via
-`--json_output` or `--csv_output` are sorted alphabetically by class name for
-easier reading. The tool exits with an error if the provided path does not exist
+`--json_output` or `--csv_output` are sorted alphabetically by class name by default.
+An optional `--sort_by count` flag sorts results by descending count instead.
+`--plot_png` saves a bar chart visualizing the class distribution (requires `matplotlib`, install with `pip install matplotlib`).
+The PNG's parent directory must already exist. The tool exits with an error if the provided path does not exist
 or is not a directory.
 
 

--- a/src/dataset_stats.py
+++ b/src/dataset_stats.py
@@ -1,4 +1,9 @@
-"""CLI to count images per class in a dataset directory."""
+"""CLI to count images per class in a dataset directory.
+
+The tool can optionally save counts as JSON, CSV or a PNG bar chart when
+``matplotlib`` is installed. Results are alphabetically ordered by default and
+can be sorted by count.
+"""
 
 import argparse
 import json
@@ -53,16 +58,86 @@ def count_images_per_class(
     return counts
 
 
-def print_stats(counts: Dict[str, int]) -> None:
+def _sort_items(counts: Dict[str, int], sort_by: str) -> list[tuple[str, int]]:
+    """Return ``counts`` items sorted by ``sort_by``.
+
+    Parameters
+    ----------
+    counts:
+        Mapping of class name to count.
+    sort_by:
+        ``"name"`` for alphabetical order or ``"count"`` for descending count.
+    """
+
+    if sort_by == "count":
+        return sorted(counts.items(), key=lambda x: (-x[1], x[0]))
+    return sorted(counts.items())
+
+
+def print_stats(counts: Dict[str, int], *, sort_by: str = "name") -> None:
     """Print formatted dataset statistics."""
     total = sum(counts.values())
-    for cls, num in sorted(counts.items()):
+    for cls, num in _sort_items(counts, sort_by):
         pct = (num / total) * 100 if total else 0
         print(f"{cls}: {num} images ({pct:.1f}% of total)")
     print(f"Total images: {total}")
 
 
-def main() -> None:
+def plot_bar(counts: Dict[str, int], output_path: str, *, sort_by: str = "name") -> None:
+    """Save a horizontal bar chart of ``counts`` to ``output_path``.
+
+    Parameters
+    ----------
+    counts:
+        Mapping of class name to number of images.
+    output_path:
+        Destination PNG file. Parent directories must exist.
+    sort_by:
+        ``"name"`` for alphabetical order or ``"count"`` for descending count.
+
+    Raises
+    ------
+    RuntimeError
+        If ``matplotlib`` is not available.
+    FileNotFoundError
+        If ``output_path`` is in a non-existent directory.
+    """
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as exc:  # pragma: no cover - optional dep
+        raise RuntimeError("matplotlib is required for plotting") from exc
+
+    output_file = Path(output_path)
+    if not output_file.parent.exists():
+        raise FileNotFoundError(
+            f"Output directory '{output_file.parent}' does not exist"
+        )
+
+    items = _sort_items(counts, sort_by)
+    labels = [cls for cls, _ in items]
+    values = [num for _, num in items]
+    plt.figure(figsize=(max(6, len(labels) * 1.2), 4))
+    plt.barh(labels, values)
+    plt.xlabel("Number of images")
+    plt.tight_layout()
+    plt.savefig(output_file)
+    plt.close()
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    """Run the dataset statistics CLI.
+
+    Parameters
+    ----------
+    argv:
+        Optional list of command-line arguments. Defaults to ``sys.argv[1:]``.
+
+    The command prints class counts and can optionally save them as JSON, CSV
+    or a PNG bar chart when ``matplotlib`` is installed. Results are sorted
+    alphabetically by default; pass ``--sort_by count`` to order by descending
+    count instead. When using ``--plot_png`` the destination directory must
+    already exist.
+    """
     parser = argparse.ArgumentParser(
         description="Print number of images per class in a dataset"
     )
@@ -80,27 +155,43 @@ def main() -> None:
         help="Optional path to save counts as CSV",
     )
     parser.add_argument(
+        "--plot_png",
+        help="Optional path to save a bar chart of the counts",
+    )
+    parser.add_argument(
+        "--sort_by",
+        choices=["name", "count"],
+        default="name",
+        help="Sort output by class name or count",
+    )
+    parser.add_argument(
         "--extensions",
         nargs="*",
         help="File extensions to count (default: .jpg .jpeg .png)",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     try:
         counts = count_images_per_class(args.input_dir, args.extensions)
     except (FileNotFoundError, NotADirectoryError, ValueError) as exc:  # pragma: no cover - CLI exit
         parser.error(str(exc))
 
-    print_stats(counts)
+    print_stats(counts, sort_by=args.sort_by)
     if args.json_output:
+        ordered = {cls: num for cls, num in _sort_items(counts, args.sort_by)}
         Path(args.json_output).write_text(
-            json.dumps(counts, indent=2, sort_keys=True)
+            json.dumps(ordered, indent=2)
         )
     if args.csv_output:
         csv_lines = ["class,count"]
-        for cls, count in sorted(counts.items()):
+        for cls, count in _sort_items(counts, args.sort_by):
             csv_lines.append(f"{cls},{count}")
         Path(args.csv_output).write_text("\n".join(csv_lines))
+    if args.plot_png:
+        try:
+            plot_bar(counts, args.plot_png, sort_by=args.sort_by)
+        except RuntimeError as exc:  # pragma: no cover - optional dep
+            parser.error(str(exc))
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry

--- a/tests/test_dataset_stats.py
+++ b/tests/test_dataset_stats.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 import pytest
 
+from src import dataset_stats
 from src.dataset_stats import count_images_per_class
 
 
@@ -12,6 +13,8 @@ def test_dataset_stats_cli_help() -> None:
     assert result.returncode == 0
     assert b"input_dir" in result.stdout
     assert b"extensions" in result.stdout
+    assert b"--plot_png" in result.stdout
+    assert b"--sort_by" in result.stdout
 
 
 def test_count_images_per_class(tmp_path) -> None:
@@ -62,6 +65,38 @@ def test_dataset_stats_csv_output(tmp_path) -> None:
     assert csv_path.read_text().strip().splitlines()[1] == "cls,1"
 
 
+def test_dataset_stats_sort_by_count(tmp_path) -> None:
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "img1.jpg").write_text("x")
+    (tmp_path / "a" / "img2.jpg").write_text("x")
+    (tmp_path / "b").mkdir()
+    (tmp_path / "b" / "img.jpg").write_text("x")
+    csv_path = tmp_path / "counts.csv"
+    json_path = tmp_path / "counts.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "src.dataset_stats",
+            "--input_dir",
+            str(tmp_path),
+            "--csv_output",
+            str(csv_path),
+            "--json_output",
+            str(json_path),
+            "--sort_by",
+            "count",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    lines = csv_path.read_text().strip().splitlines()
+    assert lines[1].startswith("a,")  # a has 2 images
+    json_data = json_path.read_text().splitlines()
+    assert json_data[1].strip().startswith('"a"')
+
+
 def test_dataset_stats_json_output(tmp_path) -> None:
     (tmp_path / "cls").mkdir()
     (tmp_path / "cls" / "img.jpg").write_text("x")
@@ -81,6 +116,73 @@ def test_dataset_stats_json_output(tmp_path) -> None:
     )
     assert result.returncode == 0
     assert json_path.read_text().strip() == "{\n  \"cls\": 1\n}"
+
+
+def test_dataset_stats_plot_output(tmp_path) -> None:
+    matplotlib = pytest.importorskip("matplotlib")  # noqa: F841
+    (tmp_path / "cls").mkdir()
+    (tmp_path / "cls" / "img.jpg").write_text("x")
+    plot_path = tmp_path / "counts.png"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "src.dataset_stats",
+            "--input_dir",
+            str(tmp_path),
+            "--plot_png",
+            str(plot_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert plot_path.exists()
+
+
+def test_dataset_stats_plot_missing_dep(tmp_path, monkeypatch, capsys) -> None:
+    (tmp_path / "cls").mkdir()
+    (tmp_path / "cls" / "img.jpg").write_text("x")
+    def fake_import(name, *args, **kwargs):
+        if name == "matplotlib.pyplot":
+            raise ImportError
+        return orig_import(name, *args, **kwargs)
+
+    import builtins
+
+    orig_import = builtins.__import__
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(SystemExit) as exc:
+        dataset_stats.main([
+            "--input_dir",
+            str(tmp_path),
+            "--plot_png",
+            str(tmp_path / "out.png"),
+        ])
+    assert exc.value.code == 2
+    assert "matplotlib is required for plotting" in capsys.readouterr().err
+
+
+def test_dataset_stats_plot_missing_dir(tmp_path) -> None:
+    matplotlib = pytest.importorskip("matplotlib")  # noqa: F841
+    (tmp_path / "cls").mkdir()
+    (tmp_path / "cls" / "img.jpg").write_text("x")
+    missing_dir = tmp_path / "missing"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "src.dataset_stats",
+            "--input_dir",
+            str(tmp_path),
+            "--plot_png",
+            str(missing_dir / "out.png"),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "Output directory" in result.stderr
 
 
 def test_count_images_missing_dir(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- allow sorting dataset counts by class name or count
- document the `--sort_by` option across docs and changelog
- support sorting for bar chart output
- test sorting behaviour and update CLI help test
- clarify dataset_stats main docstring with more details on new options

## Testing
- `ruff check src/dataset_stats.py`
- `bandit -r src -ll`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ffffb7f6c8329bd6eefab57248bc8